### PR TITLE
xdg-user-dirs support

### DIFF
--- a/meh.sh
+++ b/meh.sh
@@ -6,17 +6,21 @@
 # cron has no PATH, so let's fix that first
 export PATH=/bin:/usr/bin
 
-# where the script itself is stored
-DIR="$( cd "$( dirname "$0" )" && pwd )"
-
-PHOTO_DIR=$DIR/photos
-
-if [ ! -d $PHOTO_DIR ]
-then
-    mkdir -p $PHOTO_DIR
+# if not run by root, use x.org conformant method to retrieve user pictures
+# directory, see http://freedesktop.org/wiki/Software/xdg-user-dirs
+if [ $(id -u) -ne 0 ]
+  DIR="$(xdg-user-dir PICTURES)"/meh
+else
+  # where the script itself is stored
+  DIR="$( cd "$( dirname "$0" )" && pwd )"/photos
 fi
 
-cd $PHOTO_DIR
+if [ ! -d $DIR ]
+then
+    mkdir -p $DIR
+fi
+
+cd $DIR
 
 # sleep for a random amount of minutes, so we don't know, when the photo is
 # taken


### PR DESCRIPTION
This is a quick fix to support [xdg-user-dirs](http://freedesktop.org/wiki/Software/xdg-user-dirs) if the script is run by a user, applicable if run e.g. by user crontab or crontab configuration.
