### PR TITLE
Missing 'then' statement in if clause

### DIFF
--- a/meh.sh
+++ b/meh.sh
@@ -9,6 +9,7 @@ export PATH=/bin:/usr/bin
 # if not run by root, use x.org conformant method to retrieve user pictures
 # directory, see http://freedesktop.org/wiki/Software/xdg-user-dirs
 if [ $(id -u) -ne 0 ]
+then
   DIR="$(xdg-user-dir PICTURES)"/meh
 else
   # where the script itself is stored


### PR DESCRIPTION
Somehow there's a missing 'then' that didn't get noticed:

:~/src/meh$ ./meh.sh 
./meh.sh: line 13: syntax error near unexpected token `else'
./meh.sh: line 13:`else'
